### PR TITLE
inventorycheckformat accelerated test

### DIFF
--- a/tests/testthat/test-inventorycheckformat.R
+++ b/tests/testthat/test-inventorycheckformat.R
@@ -11,14 +11,16 @@ test_that("inventorycheckformat", {
   ## check if all the variables are detected
   ### Create the test inventory
   DetectVar <- Paracou6_2016 %>%
-    dplyr::select(-Species,-CensusYear,-idTree,-Family,-Genus,-Species,-CircCorr,-CodeAlive,-CommercialSp,-UTMZone,-Lat,-Lon,-Xfield,-Yfield,-Xutm,-Yutm) %>%
+    dplyr::select(-Species,-CensusYear,-idTree,-Family,-Genus,-Species,-CircCorr,-CodeAlive,
+                  -CommercialSp,-UTMZone,-Lat,-Lon,-Xfield,-Yfield,-Xutm,-Yutm) %>%
     dplyr::rename(Vernacular = VernName) %>%
     dplyr::rename(PLOT = Plot)
 
   ### Test
+  errors <- capture_error(inventorycheckformat(DetectVar))
   lapply(c("Plot","CensusYear","idTree","Family","Genus","Species","CircCorr","CodeAlive","CommercialSp",
            "UTMZone","Lat","Lon","VernName","Xfield","Yfield","Xutm","Yutm"), function(element)
-             expect_error(inventorycheckformat(DetectVar), regexp = element))
+             expect_match(errors$message, regexp = element))
 
   ## check if class to detect are the right ones
   ### Create the test inventory
@@ -31,9 +33,10 @@ test_that("inventorycheckformat", {
     dplyr::mutate_if(is.logical, as.factor)
 
   ### Test
+  errors <- capture_error(inventorycheckformat(RightClasses))
   lapply(c("Plot","CensusYear","idTree","Family","Genus","Species","CircCorr","CodeAlive","CommercialSp",
            "UTMZone","Lat","Lon","VernName","Xfield","Yfield","Xutm","Yutm"), function(element)
-             expect_error(inventorycheckformat(RightClasses), regexp = element))
+             expect_match(errors$message, regexp = element))
 
   expect_identical(inventorycheckformat(Paracou6_2016), Paracou6_2016) # test if the function's ouptut is the same that its input
 


### PR DESCRIPTION
Congrats, `inventorycheckformat` is perfect!

I just  accelerated by 3 (0.6s -> 0.2s) the test with a little trick. I'm generating only one time the errors and then I use the `lapply` to test the presence of the expected words instead of generating each time the error:

```
  errors <- capture_error(inventorycheckformat(DetectVar))
  lapply(c("Plot","CensusYear","idTree","Family","Genus","Species","CircCorr","CodeAlive","CommercialSp",
           "UTMZone","Lat","Lon","VernName","Xfield","Yfield","Xutm","Yutm"), function(element)
             expect_match(errors$message, regexp = element))
```